### PR TITLE
removed private marker for sshClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export interface IScpOptions {
 
 export class ScpClient extends EventEmitter {
   sftpWrapper: SFTPWrapper | null = null
-  private sshClient: SSHClient | null = null
+  sshClient: SSHClient | null = null
   remotePathSep = posix.sep
   endCalled = false
   errorHandled = false


### PR DESCRIPTION
I needed to access the sshClient in my build scripts, but typescript throws an error because it was marked as private. It would be great to make it accessible. Thanks!