### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-scp",
   "title": "SCP module for NodeJS",
   "description": "Lightweight, fast and secure SCP function for NodeJS",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "ssh2": "^1.14.0"
+    "ssh2": "^1.16.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",


### PR DESCRIPTION
Bump ssh2 to Fix TypeError: isDate is not a function caused by ssh2, they fixed it here:

https://github.com/mscdex/ssh2/commit/4f771c92daab356afbe56f0a40ea2a540b0b6beb